### PR TITLE
Preserving XML namespaces

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 
 gem "rubocop", "~> 1.21"
+
+gem "shale", git: "git@github.com:MuhammadAhsan252/shale.git", branch: "preserve-xml-namespaces"

--- a/lib/xmi/uml.rb
+++ b/lib/xmi/uml.rb
@@ -486,6 +486,7 @@ module Xmi
       xml do
         root "Profile"
         # namespace "http://www.omg.org/spec/UML/20131001", "uml"
+        preserve_namespaces true
 
         map_attribute "id", to: :id, namespace: "http://www.omg.org/spec/XMI/20161101", prefix: "xmi"
         map_attribute "name", to: :name


### PR DESCRIPTION
This PR updates **Shale** gem's source and adds the `preserve_namespaces: true` flag to the `Profile` model.

closes #7 