### PR TITLE
fixes for attribute type

### DIFF
--- a/lib/xmi/sparx.rb
+++ b/lib/xmi/sparx.rb
@@ -746,7 +746,7 @@ module Xmi
     end
 
     class SparxDiagramStyle < Lutaml::Model::Serializable
-      attribute :value, SparxDiagramElement
+      attribute :value, :string
 
       xml do
         map_attribute "value", to: :value

--- a/lib/xmi/uml.rb
+++ b/lib/xmi/uml.rb
@@ -43,7 +43,7 @@ module Xmi
           attribute :name, :string
           attribute :type_attr, :string
           attribute :uml_type, Uml::Type
-          attribute :member_end, MemberEnd
+          attribute :member_end, :string
           attribute :lower, :integer
           attribute :upper, :integer
           attribute :is_composite, :boolean
@@ -467,7 +467,6 @@ module Xmi
       xml do
         root "packageImport"
 
-        map_attribute "id", to: :id, namespace: "http://www.omg.org/spec/XMI/20131001", prefix: "xmi"
         map_attribute "id", to: :id, namespace: "http://www.omg.org/spec/XMI/20131001", prefix: "xmi"
 
         map_element "importedPackage", to: :imported_package, namespace: nil, prefix: nil


### PR DESCRIPTION
@kwkwan @ronaldtse 
The issue was **Incorrect mappings**: `attribute` types are mapped to classes rather than strings. Actually, in `lutaml-model`, now we are strictly checking the `type` of `attribute`.

fixes lutaml/lutaml-model#290
fixes lutaml/lutaml-model#291