### PR TITLE
fix: use Register#add_fallback to prevent TypeContext split-brain

### DIFF
--- a/lib/xmi/version_registry.rb
+++ b/lib/xmi/version_registry.rb
@@ -158,7 +158,8 @@ module Xmi
           # Extend fallback chain only if it won't create a cycle.
           # A cycle would occur if reg's fallback chain includes primary_register.
           # We check this by seeing if primary_register.id appears in reg's fallback.
-          primary_register.fallback << reg.id unless reg.fallback.include?(primary_register.id)
+          # Use add_fallback to keep Register and TypeContext in sync and invalidate caches.
+          primary_register.add_fallback(reg.id) unless reg.fallback.include?(primary_register.id)
         end
       end
       # rubocop:enable Metrics/CyclomaticComplexity


### PR DESCRIPTION
## Summary
- Replace direct `fallback <<` array mutation with `Register#add_fallback` in `VersionRegistry#extend_fallback_for_mixed_namespaces`
- `add_fallback` coordinates both the Register-level fallback array AND the frozen TypeContext, and invalidates caches
- Prevents split-brain where the Register has a fallback but the TypeContext does not

## Context
Requires lutaml/lutaml-model#main with the new `Register#add_fallback` method. This is a low-priority improvement — XMI tests pass without this change, but it ensures cache consistency when dynamically extending fallback chains for mixed-version documents.

## Test plan
- [x] All 186 XMI specs pass (0 failures, 4 pending performance-gated tests)