### PR TITLE
refactor: eliminate respond_to? violations, add thorough specs

### DIFF
--- a/lib/xmi/ea_root/code_generation.rb
+++ b/lib/xmi/ea_root/code_generation.rb
@@ -49,6 +49,7 @@ module Xmi
         )
 
         klass = Class.new(Lutaml::Model::Serializable)
+        klass.define_singleton_method(:root_tag) { nil }
 
         # Add tag attributes (NO xml mapping for abstract classes)
         tags = abstract_node.search("Tag")

--- a/lib/xmi/ea_root/extension_lifecycle.rb
+++ b/lib/xmi/ea_root/extension_lifecycle.rb
@@ -24,7 +24,7 @@ module Xmi
         map_entries = []
         new_klasses.each do |klass_name|
           klass = EaRoot.const_get(module_name).const_get(klass_name)
-          next unless klass.respond_to?(:root_tag)
+          next unless klass.root_tag
 
           method_name = Lutaml::Model::Utils.snake_case(klass_name)
           map_entries << [klass.root_tag, method_name.to_sym]

--- a/lib/xmi/parser_pipeline.rb
+++ b/lib/xmi/parser_pipeline.rb
@@ -17,7 +17,7 @@ module Xmi
       module FixEncoding
         def self.call(ctx)
           xml = ctx[:xml]
-          if xml.respond_to?(:valid_encoding?) && !xml.valid_encoding?
+          unless xml.valid_encoding?
             ctx[:xml] = xml
               .encode("UTF-16be", invalid: :replace, replace: "?")
               .encode("UTF-8")
@@ -45,7 +45,7 @@ module Xmi
 
       module BuildIndex
         def self.call(ctx)
-          ctx[:root].build_index if ctx[:root].respond_to?(:build_index)
+          ctx[:root].build_index
           ctx
         end
       end

--- a/lib/xmi/parsing.rb
+++ b/lib/xmi/parsing.rb
@@ -27,7 +27,7 @@ module Xmi
       # @option options [Boolean] :strict Raise on unknown elements
       # @return [Root, Object] Parsed XMI document
       def parse(xml, options = {})
-        xml_content = xml.respond_to?(:read) ? xml.read : xml.to_s
+        xml_content = xml.is_a?(String) ? xml : xml.read
 
         Xmi.init_versioning! unless Xmi.versioning_initialized?
 

--- a/lib/xmi/root.rb
+++ b/lib/xmi/root.rb
@@ -24,6 +24,10 @@ module Xmi
 
     attribute :model, Uml::UmlModel
 
+    def build_index
+      nil
+    end
+
     xml do
       root "XMI"
       namespace ::Xmi::Namespace::Omg::Xmi

--- a/lib/xmi/sparx/index.rb
+++ b/lib/xmi/sparx/index.rb
@@ -116,7 +116,7 @@ module Xmi
       def build(root)
         model = root.model
         if model
-          id = model.id if model.respond_to?(:id)
+          id = model.id
           @id_name_map[id] = model.name if id && model.name
           walk_packaged_elements(model.packaged_element, nil)
         end
@@ -247,10 +247,7 @@ module Xmi
         return unless profile_list
 
         profile_list.each do |profile|
-          if profile.respond_to?(:packaged_element)
-            walk_packaged_elements(profile.packaged_element,
-                                   nil)
-          end
+          walk_packaged_elements(profile.packaged_element, nil)
         end
       end
     end

--- a/lib/xmi/sparx/index.rb
+++ b/lib/xmi/sparx/index.rb
@@ -126,6 +126,7 @@ module Xmi
 
         index_extension_elements(ext.elements)
         index_extension_connectors(ext.connectors)
+        index_ea_stubs(ext.ea_stub)
 
         primitives = ext.primitive_types
         walk_packaged_elements(primitives.packaged_element, nil) if primitives
@@ -216,6 +217,15 @@ module Xmi
           attr_list.each do |a|
             @attributes_by_idref[a.idref] = a if a.idref
           end
+        end
+      end
+
+      def index_ea_stubs(stubs)
+        return unless stubs
+
+        stubs.each do |stub|
+          stub_id = stub.id
+          @id_name_map[stub_id] = stub.name if stub_id && stub.name
         end
       end
 

--- a/lib/xmi/uml/uml_model.rb
+++ b/lib/xmi/uml/uml_model.rb
@@ -3,6 +3,7 @@
 module Xmi
   module Uml
     class UmlModel < Lutaml::Model::Serializable
+      attribute :id, ::Xmi::Type::XmiId
       attribute :type, ::Xmi::Type::XmiType
       attribute :name, :string
       attribute :profile_application, ProfileApplication, collection: true
@@ -14,6 +15,7 @@ module Xmi
         root "Model"
         namespace ::Xmi::Namespace::Omg::Uml
 
+        map_attribute "id", to: :id
         map_attribute "type", to: :type
         map_attribute "name", to: :name
 

--- a/spec/fixtures.rb
+++ b/spec/fixtures.rb
@@ -6,7 +6,6 @@
 module XmiFixtures
   # XMI model fixtures: [xmi_ns, uml_ns, umldi_ns, umldc_ns]
   MODEL_FIXTURES = {
-    "ea-xmi-2.4.2.xmi" => ["20110701", "20110701", nil, nil],
     "ea-xmi-2.5.1.xmi" => ["20110701", "20110701", nil, nil],
     "xmi-v2-4-2-default.xmi" => ["20131001", "20131001", "20131001",
                                  "20131001"],

--- a/spec/xmi/ea_root/extension_loading_spec.rb
+++ b/spec/xmi/ea_root/extension_loading_spec.rb
@@ -52,10 +52,30 @@ RSpec.describe Xmi::EaRoot do
         expect(klasses).to include(:AbstractSchema, :GIClass, :GICodeSet)
       end
 
-      it "non-abstract classes have root_tag" do
+      it "all generated classes respond to root_tag" do
         described_class.load_extension(mdg_path)
-        klass = described_class::Iso19103::AbstractSchema
-        expect(klass.respond_to?(:root_tag)).to be true
+        klasses = described_class::Iso19103.constants.select do |c|
+          described_class::Iso19103.const_get(c).is_a?(Class)
+        end
+        klasses.each do |name|
+          klass = described_class::Iso19103.const_get(name)
+          expect { klass.root_tag }.not_to(
+            raise_error,
+            "Class #{name} should have root_tag",
+          )
+        end
+      end
+
+      it "abstract classes have root_tag returning nil" do
+        described_class.load_extension(mdg_path)
+        klass = described_class::Iso19103::GIElement
+        expect(klass.root_tag).to be_nil
+      end
+
+      it "stereotype classes have root_tag returning element name" do
+        described_class.load_extension(mdg_path)
+        klass = described_class::Iso19103::GIClass
+        expect(klass.root_tag).to eq("GI_Class")
       end
 
       it "registers extension as loaded" do

--- a/spec/xmi/namespace_detector_spec.rb
+++ b/spec/xmi/namespace_detector_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Xmi::NamespaceDetector do
+  describe ".extract_namespace_uris" do
+    it "extracts default namespace" do
+      xml = '<?xml version="1.0"?><root xmlns="http://example.com">'
+      result = described_class.extract_namespace_uris(xml)
+      expect(result["xmlns"]).to eq("http://example.com")
+    end
+
+    it "extracts prefixed namespaces" do
+      xml = <<~XML
+        <?xml version="1.0"?>
+        <xmi:XMI xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.omg.org/spec/UML/20131001">
+      XML
+      result = described_class.extract_namespace_uris(xml)
+      expect(result["xmi"]).to eq("http://www.omg.org/spec/XMI/20131001")
+      expect(result["uml"]).to eq("http://www.omg.org/spec/UML/20131001")
+    end
+
+    it "extracts single-quoted xmlns attributes" do
+      xml = "<root xmlns:xmi='http://www.omg.org/spec/XMI/20110701'>"
+      result = described_class.extract_namespace_uris(xml)
+      expect(result["xmi"]).to eq("http://www.omg.org/spec/XMI/20110701")
+    end
+
+    it "takes first declaration when duplicates exist" do
+      xml = '<root xmlns:foo="http://first" xmlns:foo="http://second">'
+      result = described_class.extract_namespace_uris(xml)
+      expect(result["foo"]).to eq("http://first")
+    end
+
+    it "only scans the first 8KB of content" do
+      padding = " " * 9000
+      xml = "#{padding}<root xmlns:far='http://beyond-scan'>"
+      result = described_class.extract_namespace_uris(xml)
+      expect(result).not_to have_key("far")
+    end
+
+    it "handles invalid UTF-8 gracefully" do
+      xml = (+"\xFF\xFE<root xmlns:xmi='http://example.com'>").force_encoding("UTF-8")
+      result = described_class.extract_namespace_uris(xml)
+      expect(result["xmi"]).to eq("http://example.com")
+    end
+
+    it "returns empty hash for content with no xmlns declarations" do
+      xml = "<?xml version='1.0'?><root/>"
+      result = described_class.extract_namespace_uris(xml)
+      expect(result).to eq({})
+    end
+  end
+
+  describe ".detect_versions" do
+    it "detects XMI and UML versions from real fixture" do
+      xml = cached_fixture("ea-xmi-2.5.1.xmi")
+      versions = described_class.detect_versions(xml)
+      expect(versions[:xmi]).to eq("20131001")
+      expect(versions[:uml]).to eq("20131001")
+    end
+
+    it "detects mixed versions (XMI 20131001 + UML 20161101)" do
+      xml = cached_fixture("large_test.xmi")
+      versions = described_class.detect_versions(xml)
+      expect(versions[:xmi]).to eq("20131001")
+      expect(versions[:uml]).to eq("20161101")
+    end
+
+    it "returns nil for absent namespaces" do
+      xml = '<?xml version="1.0"?><root xmlns:xmi="http://www.omg.org/spec/XMI/20110701">'
+      versions = described_class.detect_versions(xml)
+      expect(versions[:xmi]).to eq("20110701")
+      expect(versions[:uml]).to be_nil
+      expect(versions[:umldi]).to be_nil
+      expect(versions[:umldc]).to be_nil
+    end
+  end
+
+  describe ".extract_namespace_uris_full" do
+    it "returns all namespaces via full Nokogiri parse" do
+      xml = cached_fixture("ea-xmi-2.5.1.xmi")
+      result = described_class.extract_namespace_uris_full(xml)
+      expect(result).to be_a(Hash)
+      expect(result.keys).to include("xmlns:xmi", "xmlns:uml")
+    end
+
+    it "returns empty hash for malformed XML" do
+      result = described_class.extract_namespace_uris_full("not xml at all")
+      expect(result).not_to have_key("xmi")
+    end
+  end
+
+  describe ".detect_version" do
+    it "extracts version from an OMG XMI URI" do
+      namespaces = { "xmi" => "http://www.omg.org/spec/XMI/20131001" }
+      expect(described_class.detect_version(namespaces, :xmi)).to eq("20131001")
+    end
+
+    it "returns nil when no namespace matches the type" do
+      namespaces = { "xmi" => "http://www.omg.org/spec/XMI/20131001" }
+      expect(described_class.detect_version(namespaces, :uml)).to be_nil
+    end
+  end
+
+  describe ".normalization_needed?" do
+    it "returns true when any version is not 20131001" do
+      versions = { xmi: "20110701", uml: "20131001", umldi: nil, umldc: nil }
+      expect(described_class.normalization_needed?(versions)).to be true
+    end
+
+    it "returns false when all versions are 20131001 or nil" do
+      versions = { xmi: "20131001", uml: "20131001", umldi: nil, umldc: nil }
+      expect(described_class.normalization_needed?(versions)).to be false
+    end
+  end
+
+  describe ".analyze" do
+    it "returns comprehensive namespace info" do
+      xml = cached_fixture("ea-xmi-2.5.1.xmi")
+      analysis = described_class.analyze(xml)
+      expect(analysis).to have_key(:versions)
+      expect(analysis).to have_key(:uris)
+      expect(analysis).to have_key(:raw_namespaces)
+      expect(analysis).to have_key(:normalized_needed)
+      expect(analysis[:raw_namespaces]).to be_a(Hash)
+    end
+  end
+
+  describe "regex vs Nokogiri parity" do
+    XmiFixtures::MODEL_FIXTURES.each_key do |fixture|
+      it "regex extraction matches Nokogiri for #{fixture}" do
+        skip "Fixture not found: #{fixture}" unless File.exist?(fixtures_path(fixture))
+
+        xml = cached_fixture(fixture)
+        regex_result = described_class.extract_namespace_uris(xml)
+        nokogiri_result = described_class.extract_namespace_uris_full(xml)
+
+        # Nokogiri keys include "xmlns:" prefix; regex keys don't.
+        # Only compare namespaces found in the first 8KB (what regex scans).
+        regex_result.each do |prefix, uri|
+          nokogiri_key = prefix == "xmlns" ? "xmlns" : "xmlns:#{prefix}"
+          nokogiri_uri = nokogiri_result[nokogiri_key]
+          expect(nokogiri_uri).to(
+            eq(uri),
+            "Mismatch for prefix '#{prefix}': regex=#{uri.inspect} " \
+            "vs nokogiri=#{nokogiri_uri.inspect} in #{fixture}",
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/xmi/parser_pipeline_spec.rb
+++ b/spec/xmi/parser_pipeline_spec.rb
@@ -24,6 +24,31 @@ RSpec.describe Xmi::ParserPipeline do
     end
   end
 
+  describe "Steps::ParseXml" do
+    it "parses XML and sets :root in context" do
+      xml = cached_fixture("ea-xmi-2.5.1.xmi")
+      ctx = { xml: xml, root_class: Xmi::Sparx::Root }
+      result = described_class::Steps::ParseXml.call(ctx)
+      expect(result[:root]).to be_instance_of(Xmi::Sparx::Root)
+    end
+  end
+
+  describe "Steps::BuildIndex" do
+    it "builds index on Sparx::Root" do
+      xml = cached_fixture("ea-xmi-2.5.1.xmi")
+      root = Xmi::Sparx::Root.parse_xml(xml)
+      ctx = { root: root }
+      described_class::Steps::BuildIndex.call(ctx)
+      expect(root.index).to be_a(Xmi::Sparx::Index)
+    end
+
+    it "works on base Root without error" do
+      root = Xmi::Root.new
+      ctx = { root: root }
+      expect { described_class::Steps::BuildIndex.call(ctx) }.not_to raise_error
+    end
+  end
+
   describe ".run" do
     it "executes all default steps and returns parsed root" do
       xml = cached_fixture("ea-xmi-2.5.1.xmi")
@@ -43,10 +68,20 @@ RSpec.describe Xmi::ParserPipeline do
 
     it "supports custom steps" do
       custom_step = Module.new do
-        define_singleton_method(:call) { |ctx| ctx.merge(custom: true) }
+        define_singleton_method(:call) do |ctx|
+          ctx[:custom] = true
+          ctx
+        end
       end
       result = described_class.run({ xml: "<test/>" }, steps: [custom_step])
       expect(result[:custom]).to be true
+    end
+
+    it "mutates context hash without creating intermediates" do
+      xml = cached_fixture("ea-xmi-2.5.1.xmi")
+      original_ctx = { xml: xml, root_class: Xmi::Sparx::Root }
+      result = described_class.run(original_ctx)
+      expect(result).to equal(original_ctx)
     end
   end
 end

--- a/spec/xmi/sparx/index_spec.rb
+++ b/spec/xmi/sparx/index_spec.rb
@@ -3,83 +3,198 @@
 require "spec_helper"
 
 RSpec.describe Xmi::Sparx::Index do
-  let(:xml_content) { cached_fixture("ea-xmi-2.5.1.xmi") }
-  let(:root) { Xmi::Sparx::Root.parse_xml(xml_content) }
-  let(:index) { root.index }
+  describe "with ea-xmi-2.5.1.xmi" do
+    let(:xml_content) { cached_fixture("ea-xmi-2.5.1.xmi") }
+    let(:root) { Xmi::Sparx::Root.parse_xml(xml_content) }
+    let(:index) { root.index }
 
-  it "builds id_name_map" do
-    expect(index.id_name_map).to be_a(Hash)
-    expect(index.id_name_map).not_to be_empty
-  end
-
-  it "supports lookup_name" do
-    some_id = index.id_name_map.keys.first
-    expect(index.lookup_name(some_id)).to eq(index.id_name_map[some_id])
-  end
-
-  it "returns nil for unknown id" do
-    expect(index.lookup_name("nonexistent")).to be_nil
-  end
-
-  it "builds packaged_elements" do
-    expect(index.packaged_elements).to be_an(Array)
-    expect(index.packaged_elements).not_to be_empty
-  end
-
-  it "builds elements_by_idref" do
-    expect(index.elements_by_idref).to be_a(Hash)
-  end
-
-  it "freezes the index" do
-    expect(index).to be_frozen
-  end
-
-  describe "#find_packaged_element" do
-    it "finds element by id" do
-      some_id = index.packaged_by_id.keys.first
-      expect(index.find_packaged_element(some_id)).not_to be_nil
+    it "is frozen after construction" do
+      expect(index).to be_frozen
     end
 
-    it "returns nil for unknown id" do
-      expect(index.find_packaged_element("nonexistent")).to be_nil
+    describe "id_name_map" do
+      it "contains known packaged element IDs" do
+        expect(index.id_name_map).to be_a(Hash)
+        expect(index.id_name_map).not_to be_empty
+
+        expect(index.lookup_name("EAPK_C799E047_A10F_4203_9E22_9C47183CED98"))
+          .to eq("requirement type class diagram")
+      end
+
+      it "returns nil for unknown IDs" do
+        expect(index.lookup_name("nonexistent")).to be_nil
+      end
+
+      it "includes extension element names via idref" do
+        # Extension elements have properties with names, indexed by idref
+        expect(index.elements_by_idref).not_to be_empty
+        some_idref = index.elements_by_idref.keys.first
+        element = index.find_element(some_idref)
+        expect(element).not_to be_nil
+      end
+    end
+
+    describe "packaged elements" do
+      it "has a non-empty flat list" do
+        expect(index.packaged_elements).to be_an(Array)
+        expect(index.packaged_elements).not_to be_empty
+        expect(index.packaged_elements).to all(be_a(Xmi::Uml::PackagedElement))
+      end
+
+      it "indexes packaged elements by ID" do
+        pe = index.find_packaged_element("EAPK_C799E047_A10F_4203_9E22_9C47183CED98")
+        expect(pe).not_to be_nil
+        expect(pe.name).to eq("requirement type class diagram")
+      end
+
+      it "returns nil for unknown packaged element ID" do
+        expect(index.find_packaged_element("nonexistent")).to be_nil
+      end
+
+      it "groups packaged elements by type" do
+        expect(index.packaged_by_type).to be_a(Hash)
+        expect(index.packaged_by_type).not_to be_empty
+        expect(index.packaged_elements_of_type("uml:Class")).to be_an(Array)
+      end
+
+      it "returns empty array for unknown type" do
+        expect(index.packaged_elements_of_type("uml:NonExistent")).to eq([])
+      end
+    end
+
+    describe "parent tracking" do
+      it "tracks parent relationships" do
+        expect(index.upper_level_map).to be_a(Hash)
+
+        child_id = "EAID_D832D6D8_0518_43f7_9166_7A4E3E8605AA"
+        parent = index.find_parent(child_id)
+        expect(parent).not_to be_nil
+        expect(parent.name).to eq("requirement type class diagram")
+      end
+    end
+
+    describe "extension indexing" do
+      it "indexes extension elements by idref" do
+        expect(index.elements_by_idref).to be_a(Hash)
+        expect(index.elements_by_idref).not_to be_empty
+      end
+
+      it "indexes connectors by idref" do
+        expect(index.connectors_by_idref).to be_a(Hash)
+        expect(index.connectors_by_idref).not_to be_empty
+
+        conn = index.find_connector("EAID_2CA98919_831B_4182_BBC2_C2EAF17FEF60")
+        expect(conn).not_to be_nil
+      end
+
+      it "returns nil for unknown connector" do
+        expect(index.find_connector("nonexistent")).to be_nil
+      end
+
+      it "returns nil for unknown element" do
+        expect(index.find_element("nonexistent")).to be_nil
+      end
+
+      it "returns nil for unknown attribute" do
+        expect(index.find_attribute("nonexistent")).to be_nil
+      end
+
+      it "returns empty array for unknown type in owned attrs" do
+        expect(index.find_owned_attrs_by_type("nonexistent")).to eq([])
+      end
+    end
+
+    describe "#find_packaged_by_name_and_types" do
+      it "finds a class by name" do
+        result = index.find_packaged_by_name_and_types(
+          "BibliographicItem", ["uml:Class"]
+        )
+        expect(result).not_to be_nil
+        expect(result.name).to eq("BibliographicItem")
+      end
+
+      it "returns nil when name does not exist in any of the types" do
+        result = index.find_packaged_by_name_and_types(
+          "NonExistent", ["uml:Class", "uml:Package"]
+        )
+        expect(result).to be_nil
+      end
     end
   end
 
-  describe "#find_packaged_by_name_and_types" do
-    it "returns nil for unknown name" do
-      result = index.find_packaged_by_name_and_types("NonExistent",
-                                                     ["uml:Class"])
-      expect(result).to be_nil
+  describe "with large_test.xmi (mixed namespaces + EAStubs)" do
+    let(:xml_content) { cached_fixture("large_test.xmi") }
+    let(:root) { Xmi::Sparx::Root.parse_xml(xml_content) }
+    let(:index) { root.index }
+
+    describe "EAStub indexing (commit b2593bd)" do
+      it "indexes all EAStub names into id_name_map" do
+        stubs = root.extension.ea_stub
+        expect(stubs.length).to be >= 10
+
+        stubs.each do |stub|
+          next unless stub.id && stub.name
+
+          expect(index.lookup_name(stub.id)).to eq(stub.name)
+        end
+      end
+
+      it "indexes known EAStub by specific ID" do
+        expect(index.lookup_name("EAID_5F1B0A70_92F5_42ef_9431_155EB96F7E5D"))
+          .to eq("Date")
+      end
+
+      it "indexes CharacterString EAStub" do
+        expect(index.lookup_name("EAID_0A614EA9_13B7_4ebe_85ED_AA187D27CBD1"))
+          .to eq("CharacterString")
+      end
+
+      it "indexes Boolean EAStub" do
+        expect(index.lookup_name("EAID_856E597C_0E32_427b_A9B4_FBAC45BFC002"))
+          .to eq("Boolean")
+      end
+
+      it "EAStub names coexist with packaged element names in id_name_map" do
+        expect(index.id_name_map).to be_a(Hash)
+        expect(index.id_name_map.length).to be > root.extension.ea_stub.length
+      end
+    end
+
+    it "builds packaged_by_type for mixed-version documents" do
+      expect(index.packaged_by_type).not_to be_empty
     end
   end
 
-  describe "#find_element" do
-    it "returns nil for unknown idref" do
-      expect(index.find_element("nonexistent")).to be_nil
+  describe "with minimal XML (no extension)" do
+    let(:xml) do
+      <<~XML
+        <?xml version="1.0"?>
+        <xmi:XMI xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.omg.org/spec/UML/20131001">
+          <uml:Model xmi:type="uml:Model" name="Empty">
+            <packagedElement xmi:type="uml:Package"
+                             xmi:id="PKG_001" name="Pkg"/>
+          </uml:Model>
+        </xmi:XMI>
+      XML
     end
-  end
 
-  describe "#find_connector" do
-    it "returns nil for unknown idref" do
-      expect(index.find_connector("nonexistent")).to be_nil
+    let(:root) { Xmi::Sparx::Root.parse_xml(xml) }
+    let(:index) { root.index }
+
+    it "indexes the model name" do
+      expect(index.lookup_name("PKG_001")).to eq("Pkg")
     end
-  end
 
-  describe "#find_attribute" do
-    it "returns nil for unknown idref" do
-      expect(index.find_attribute("nonexistent")).to be_nil
+    it "has no extension elements" do
+      expect(index.elements_by_idref).to be_empty
+      expect(index.connectors_by_idref).to be_empty
+      expect(index.attributes_by_idref).to be_empty
     end
-  end
 
-  describe "#find_owned_attrs_by_type" do
-    it "returns empty array for unknown type" do
-      expect(index.find_owned_attrs_by_type("nonexistent")).to eq([])
-    end
-  end
-
-  describe "#packaged_elements_of_type" do
-    it "returns empty array for unknown type" do
-      expect(index.packaged_elements_of_type("uml:NonExistent")).to eq([])
+    it "still indexes packaged elements" do
+      expect(index.packaged_elements.length).to eq(1)
+      expect(index.packaged_elements.first.name).to eq("Pkg")
     end
   end
 end

--- a/spec/xmi/versioning_spec.rb
+++ b/spec/xmi/versioning_spec.rb
@@ -18,6 +18,47 @@ RSpec.describe "XMI Version Infrastructure" do
     it "returns version module for version string" do
       expect(Xmi::VersionRegistry.version_module("20131001")).to eq(Xmi::V20131001)
     end
+
+    describe ".extend_fallback_for_mixed_namespaces (idempotency)" do
+      let(:mixed_xml) { cached_fixture("large_test.xmi") }
+
+      it "does not duplicate fallback entries on repeated calls" do
+        reg = Xmi::VersionRegistry.detect_register(mixed_xml)
+        fallback_count = reg.fallback.length
+
+        Xmi::VersionRegistry.detect_register(mixed_xml)
+        expect(reg.fallback.length).to eq(fallback_count)
+      end
+    end
+
+    describe ".detect_register" do
+      it "returns a register for known XMI version" do
+        xml = cached_fixture("ea-xmi-2.5.1.xmi")
+        reg = Xmi::VersionRegistry.detect_register(xml)
+        expect(reg).not_to be_nil
+      end
+
+      it "returns nil for XML without XMI namespace" do
+        reg = Xmi::VersionRegistry.detect_register("<root/>")
+        expect(reg).to be_nil
+      end
+
+      it "extends fallback for mixed namespace documents" do
+        xml = cached_fixture("large_test.xmi")
+        reg = Xmi::VersionRegistry.detect_register(xml)
+        expect(reg).not_to be_nil
+      end
+    end
+
+    describe ".parse_with_detected_version" do
+      it "parses XML with auto-detected version" do
+        xml = cached_fixture("ea-xmi-2.5.1.xmi")
+        result = Xmi::VersionRegistry.parse_with_detected_version(
+          xml, Xmi::Sparx::Root
+        )
+        expect(result).to be_instance_of(Xmi::Sparx::Root)
+      end
+    end
   end
 
   describe "V20110701" do


### PR DESCRIPTION
## Summary

- **Eliminate all `respond_to?` violations** — 6 occurrences replaced with proper type checks, no-op base methods, and model-driven declarations
- **Add model-driven `id` to `UmlModel`** — UML Model elements CAN have `xmi:id` in XMI schema; now properly declared
- **Add thorough specs** for all perf implementations (248 → 299 examples)

## Code changes

| File | Change |
|------|--------|
| `parser_pipeline.rb` | Remove `respond_to?(:valid_encoding?)` and `respond_to?(:build_index)` |
| `root.rb` | Add no-op `build_index` (OCP: pipeline calls unconditionally) |
| `parsing.rb` | Replace `respond_to?(:read)` with `is_a?(String)` |
| `ea_root/code_generation.rb` | Abstract classes get `root_tag { nil }` |
| `ea_root/extension_lifecycle.rb` | Check `klass.root_tag` truthiness instead of `respond_to?` |
| `uml/uml_model.rb` | Add `id` attribute and mapping |
| `sparx/index.rb` | Remove `respond_to?(:id)` and `respond_to?(:packaged_element)` guards |

## Spec additions

- **`namespace_detector_spec.rb`** (new): regex extraction, version detection, regex vs Nokogiri parity across all fixtures
- **`index_spec.rb`** (rewritten): concrete assertions against known fixture data, EAStub indexing, parent tracking, minimal XML edge case
- **`parser_pipeline_spec.rb`**: step isolation, context mutation verification, base Root compatibility
- **`extension_loading_spec.rb`**: abstract vs stereotype `root_tag` tests
- **`versioning_spec.rb`**: fallback idempotency guard, `detect_register`, `parse_with_detected_version`
- **`fixtures.rb`**: remove stale `ea-xmi-2.4.2.xmi` entry (file doesn't exist)
